### PR TITLE
Close Destination - createUpdateContactAndLead action

### DIFF
--- a/packages/destination-actions/src/destinations/close/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/close/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for close destination: createUpdateContactAndLead action - all fields 1`] = `
+Object {
+  "action_payload": Object {
+    "contact_custom_fields": Object {
+      "testType": "Bbzz5]ZQl",
+    },
+    "contact_email": "Bbzz5]ZQl",
+    "contact_external_id": "Bbzz5]ZQl",
+    "contact_name": "Bbzz5]ZQl",
+    "contact_phone": "Bbzz5]ZQl",
+    "contact_title": "Bbzz5]ZQl",
+    "contact_url": "Bbzz5]ZQl",
+    "lead_name": "Bbzz5]ZQl",
+  },
+  "settings": Object {
+    "contact_custom_field_id_for_user_id": "Bbzz5]ZQl",
+  },
+}
+`;
+
+exports[`Testing snapshot for close destination: createUpdateContactAndLead action - required fields 1`] = `
+Object {
+  "action_payload": Object {
+    "contact_external_id": "Bbzz5]ZQl",
+  },
+  "settings": Object {
+    "contact_custom_field_id_for_user_id": "Bbzz5]ZQl",
+  },
+}
+`;

--- a/packages/destination-actions/src/destinations/close/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/close/__tests__/index.test.ts
@@ -1,0 +1,39 @@
+import nock from 'nock'
+import { createTestIntegration } from '@segment/actions-core'
+import Definition from '../index'
+
+const testDestination = createTestIntegration(Definition)
+
+describe('Close', () => {
+  describe('testAuthentication', () => {
+    it('should validate valid api key', async () => {
+      nock('https://api.close.com/')
+        .get('/api/v1/me/')
+        .matchHeader('Authorization', 'Basic YXBpX2tleWlkLmtleXNlY3JldDo=')
+        .reply(200, {})
+
+      const settings = {
+        api_key: 'api_keyid.keysecret',
+        contact_custom_field_id_for_user_id: 'cf_id'
+      }
+      await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+    })
+
+    it('should not validate invalid api key', async () => {
+      nock('https://api.close.com/')
+        .get('/api/v1/me/')
+        .matchHeader('Authorization', 'Basic YXBpX2tleWlkLmtleXNlY3JldDo=')
+        .reply(401, {
+          error:
+            "The server could not verify that you are authorized to access the URL requested. You either supplied the wrong credentials (e.g. a bad password), or your browser doesn't understand how to supply the credentials required."
+        })
+
+      const settings = {
+        api_key: 'api_keyid.keysecret',
+        contact_custom_field_id_for_user_id: 'cf_id'
+      }
+
+      await expect(testDestination.testAuthentication(settings)).rejects.toThrowError()
+    })
+  })
+})

--- a/packages/destination-actions/src/destinations/close/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/close/__tests__/index.test.ts
@@ -14,7 +14,7 @@ describe('Close', () => {
 
       const settings = {
         api_key: 'api_keyid.keysecret',
-        contact_custom_field_id_for_user_id: 'cf_id'
+        contact_custom_field_id_for_user_id: 'cf_id1'
       }
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
     })
@@ -30,7 +30,7 @@ describe('Close', () => {
 
       const settings = {
         api_key: 'api_keyid.keysecret',
-        contact_custom_field_id_for_user_id: 'cf_id'
+        contact_custom_field_id_for_user_id: 'cf_id1'
       }
 
       await expect(testDestination.testAuthentication(settings)).rejects.toThrowError()

--- a/packages/destination-actions/src/destinations/close/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/close/__tests__/index.test.ts
@@ -17,6 +17,7 @@ describe('Close', () => {
         contact_custom_field_id_for_user_id: 'cf_id1'
       }
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
+      expect(nock.isDone()).toBe(true)
     })
 
     it('should not validate invalid api key', async () => {
@@ -34,6 +35,7 @@ describe('Close', () => {
       }
 
       await expect(testDestination.testAuthentication(settings)).rejects.toThrowError()
+      expect(nock.isDone()).toBe(true)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/close/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/close/__tests__/snapshot.test.ts
@@ -1,0 +1,77 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../lib/test-data'
+import destination from '../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const destinationSlug = 'close'
+
+describe(`Testing snapshot for ${destinationSlug} destination:`, () => {
+  for (const actionSlug in destination.actions) {
+    it(`${actionSlug} action - required fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+
+      expect(request.headers).toMatchSnapshot()
+    })
+
+    it(`${actionSlug} action - all fields`, async () => {
+      const seedName = `${destinationSlug}#${actionSlug}`
+      const action = destination.actions[actionSlug]
+      const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+      nock(/.*/).persist().get(/.*/).reply(200)
+      nock(/.*/).persist().post(/.*/).reply(200)
+      nock(/.*/).persist().put(/.*/).reply(200)
+
+      const event = createTestEvent({
+        properties: eventData
+      })
+
+      const responses = await testDestination.testAction(actionSlug, {
+        event: event,
+        mapping: event.properties,
+        settings: settingsData,
+        auth: undefined
+      })
+
+      const request = responses[0].request
+      const rawBody = await request.text()
+
+      try {
+        const json = JSON.parse(rawBody)
+        expect(json).toMatchSnapshot()
+        return
+      } catch (err) {
+        expect(rawBody).toMatchSnapshot()
+      }
+    })
+  }
+})

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -2,17 +2,31 @@
 
 exports[`Testing snapshot for Close's createUpdateContactAndLead destination action: all fields 1`] = `
 Object {
-  "contact_custom_fields": Object {
-    "testType": "AY$s*K8XPu",
+  "action_payload": Object {
+    "contact_custom_fields": Object {
+      "testType": "AY$s*K8XPu",
+    },
+    "contact_email": "AY$s*K8XPu",
+    "contact_external_id": "AY$s*K8XPu",
+    "contact_name": "AY$s*K8XPu",
+    "contact_phone": "AY$s*K8XPu",
+    "contact_title": "AY$s*K8XPu",
+    "contact_url": "AY$s*K8XPu",
+    "lead_name": "AY$s*K8XPu",
   },
-  "contact_email": "AY$s*K8XPu",
-  "contact_name": "AY$s*K8XPu",
-  "external_cf_contact_id": "AY$s*K8XPu",
+  "settings": Object {
+    "contact_custom_field_id_for_user_id": "AY$s*K8XPu",
+  },
 }
 `;
 
 exports[`Testing snapshot for Close's createUpdateContactAndLead destination action: required fields 1`] = `
 Object {
-  "external_cf_contact_id": "AY$s*K8XPu",
+  "action_payload": Object {
+    "contact_external_id": "AY$s*K8XPu",
+  },
+  "settings": Object {
+    "contact_custom_field_id_for_user_id": "AY$s*K8XPu",
+  },
 }
 `;

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing snapshot for Close's createUpdateContactAndLead destination action: all fields 1`] = `
+Object {
+  "contact_custom_fields": Object {
+    "testType": "AY$s*K8XPu",
+  },
+  "contact_email": "AY$s*K8XPu",
+  "contact_name": "AY$s*K8XPu",
+  "external_cf_contact_id": "AY$s*K8XPu",
+}
+`;
+
+exports[`Testing snapshot for Close's createUpdateContactAndLead destination action: required fields 1`] = `
+Object {
+  "external_cf_contact_id": "AY$s*K8XPu",
+}
+`;

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
@@ -47,7 +47,7 @@ describe('Close.createUpdateContactAndLead', () => {
         phone: TEST_USER_1.phone,
         website: TEST_USER_1.website,
         title: TEST_USER_1.title,
-        business_plan: 'Enterprise'
+        business_plan: TEST_USER_1.business_plan
       }
     })
 

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
@@ -21,7 +21,7 @@ const testDestination = createTestIntegration(Destination)
 describe('Close.createUpdateContactAndLead', () => {
   it('should call action with default mappings', async () => {
     nock('https://services.close.com/', { encodedQueryParams: true })
-      .post('/webhooks/segment/actions/create-update-contact-and-lead', {
+      .post('/webhooks/segment/actions/create-update-contact-and-lead/', {
         action_payload: {
           lead_name: TEST_USER_1.company_name,
           contact_name: TEST_USER_1.name,
@@ -61,7 +61,7 @@ describe('Close.createUpdateContactAndLead', () => {
 
   it('should call action with contact_custom_fields mappings', async () => {
     nock('https://services.close.com/', { encodedQueryParams: true })
-      .post('/webhooks/segment/actions/create-update-contact-and-lead', {
+      .post('/webhooks/segment/actions/create-update-contact-and-lead/', {
         action_payload: {
           contact_external_id: TEST_USER_1.id,
           contact_custom_fields: { cf_business_plan: 'Enterprise' }

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
@@ -1,0 +1,50 @@
+// import nock from 'nock'
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import Destination from '../../index'
+import dayjs from '../../../../lib/dayjs'
+import { Settings } from '../../generated-types'
+
+const testDestination = createTestIntegration(Destination)
+
+describe('Close.createUpdateContactAndLead', () => {
+  it('should work with default mappings when userId is supplied', async () => {
+    // TODO copy of test to have something now
+    const userId = 'abc123'
+    const anonymousId = 'unknown_123'
+    const timestamp = dayjs.utc().toISOString()
+    const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
+    const traits = {
+      full_name: 'Test User',
+      email: 'test@example.com',
+      created_at: timestamp,
+      person: {
+        over18: true,
+        identification: 'valid',
+        birthdate
+      }
+    }
+    const event = createTestEvent({
+      userId,
+      anonymousId,
+      timestamp,
+      traits
+    })
+    const settings: Settings = {
+      api_key: 'api_xxxx'
+    }
+    const mapping = {
+      contact_custom_fields: {
+        cf_oiiouhwedf: {
+          '@path': '$.userId'
+        }
+      }
+    }
+    const responses = await testDestination.testAction('createUpdateContactAndLead', {
+      event,
+      settings,
+      mapping,
+      useDefaultMappings: true
+    })
+    console.log(responses)
+  })
+})

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/index.test.ts
@@ -1,50 +1,97 @@
-// import nock from 'nock'
+import nock from 'nock'
 import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Destination from '../../index'
-import dayjs from '../../../../lib/dayjs'
 import { Settings } from '../../generated-types'
 
+const TEST_USER_1 = {
+  id: 'user_id_1',
+  company_name: 'My Company',
+  name: 'John',
+  email: 'john@example.com',
+  title: 'Manager',
+  phone: '+1 800 444 4444',
+  website: 'https://example.org',
+  business_plan: 'Enterprise'
+}
+const SETTINGS: Settings = {
+  api_key: 'api_keyid.keysecret',
+  contact_custom_field_id_for_user_id: 'cf_external_user_id'
+}
 const testDestination = createTestIntegration(Destination)
-
 describe('Close.createUpdateContactAndLead', () => {
-  it('should work with default mappings when userId is supplied', async () => {
-    // TODO copy of test to have something now
-    const userId = 'abc123'
-    const anonymousId = 'unknown_123'
-    const timestamp = dayjs.utc().toISOString()
-    const birthdate = dayjs.utc('1990-01-01T00:00:00Z').toISOString()
-    const traits = {
-      full_name: 'Test User',
-      email: 'test@example.com',
-      created_at: timestamp,
-      person: {
-        over18: true,
-        identification: 'valid',
-        birthdate
-      }
-    }
+  it('should call action with default mappings', async () => {
+    nock('https://services.close.com/', { encodedQueryParams: true })
+      .post('/webhooks/segment/actions/create-update-contact-and-lead', {
+        action_payload: {
+          lead_name: TEST_USER_1.company_name,
+          contact_name: TEST_USER_1.name,
+          contact_email: TEST_USER_1.email,
+          contact_phone: TEST_USER_1.phone,
+          contact_url: TEST_USER_1.website,
+          contact_title: TEST_USER_1.title,
+          contact_external_id: TEST_USER_1.id
+        },
+        settings: { contact_custom_field_id_for_user_id: 'cf_external_user_id' }
+      })
+      .matchHeader('Authorization', 'Basic YXBpX2tleWlkLmtleXNlY3JldDo=')
+      .reply(202, '')
+
     const event = createTestEvent({
-      userId,
-      anonymousId,
-      timestamp,
-      traits
+      userId: 'user_id_1',
+      traits: {
+        company: {
+          name: TEST_USER_1.company_name
+        },
+        name: TEST_USER_1.name,
+        email: TEST_USER_1.email,
+        phone: TEST_USER_1.phone,
+        website: TEST_USER_1.website,
+        title: TEST_USER_1.title,
+        business_plan: 'Enterprise'
+      }
     })
-    const settings: Settings = {
-      api_key: 'api_xxxx'
-    }
+
+    await testDestination.testAction('createUpdateContactAndLead', {
+      event,
+      settings: SETTINGS,
+      useDefaultMappings: true
+    })
+    expect(nock.isDone()).toBe(true)
+  })
+
+  it('should call action with contact_custom_fields mappings', async () => {
+    nock('https://services.close.com/', { encodedQueryParams: true })
+      .post('/webhooks/segment/actions/create-update-contact-and-lead', {
+        action_payload: {
+          contact_external_id: TEST_USER_1.id,
+          contact_custom_fields: { cf_business_plan: 'Enterprise' }
+        },
+        settings: { contact_custom_field_id_for_user_id: 'cf_external_user_id' }
+      })
+      .matchHeader('Authorization', 'Basic YXBpX2tleWlkLmtleXNlY3JldDo=')
+      .reply(202, '')
+
+    const event = createTestEvent({
+      userId: 'user_id_1',
+      traits: {
+        business_plan: 'Enterprise'
+      }
+    })
+
+    // Define mapping for business plan custom field
     const mapping = {
       contact_custom_fields: {
-        cf_oiiouhwedf: {
-          '@path': '$.userId'
+        cf_business_plan: {
+          '@path': '$.traits.business_plan'
         }
       }
     }
-    const responses = await testDestination.testAction('createUpdateContactAndLead', {
+    await testDestination.testAction('createUpdateContactAndLead', {
       event,
-      settings,
+      settings: SETTINGS,
       mapping,
       useDefaultMappings: true
     })
-    console.log(responses)
+    expect(nock.isDone()).toBe(true)
   })
 })

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/snapshot.test.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/__tests__/snapshot.test.ts
@@ -1,0 +1,75 @@
+import { createTestEvent, createTestIntegration } from '@segment/actions-core'
+import { generateTestData } from '../../../../lib/test-data'
+import destination from '../../index'
+import nock from 'nock'
+
+const testDestination = createTestIntegration(destination)
+const actionSlug = 'createUpdateContactAndLead'
+const destinationSlug = 'Close'
+const seedName = `${destinationSlug}#${actionSlug}`
+
+describe(`Testing snapshot for ${destinationSlug}'s ${actionSlug} destination action:`, () => {
+  it('required fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, true)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+
+    expect(request.headers).toMatchSnapshot()
+  })
+
+  it('all fields', async () => {
+    const action = destination.actions[actionSlug]
+    const [eventData, settingsData] = generateTestData(seedName, destination, action, false)
+
+    nock(/.*/).persist().get(/.*/).reply(200)
+    nock(/.*/).persist().post(/.*/).reply(200)
+    nock(/.*/).persist().put(/.*/).reply(200)
+
+    const event = createTestEvent({
+      properties: eventData
+    })
+
+    const responses = await testDestination.testAction(actionSlug, {
+      event: event,
+      mapping: event.properties,
+      settings: settingsData,
+      auth: undefined
+    })
+
+    const request = responses[0].request
+    const rawBody = await request.text()
+
+    try {
+      const json = JSON.parse(rawBody)
+      expect(json).toMatchSnapshot()
+      return
+    } catch (err) {
+      expect(rawBody).toMatchSnapshot()
+    }
+  })
+})

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
@@ -1,0 +1,16 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * Value to identify the contact. Custom Field id is defined in the main integration settings.
+   */
+  external_cf_contact_id: string
+  contact_name?: string
+  contact_email?: string
+  /**
+   * Custom fields to set on the Contact. Key should be custom field id (`cf_xxxx`).
+   */
+  contact_custom_fields?: {
+    [k: string]: unknown
+  }
+}

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
@@ -1,12 +1,16 @@
 // Generated file. DO NOT MODIFY IT BY HAND.
 
 export interface Payload {
-  /**
-   * Value to identify the contact. Custom Field id is defined in the main integration settings.
-   */
-  external_cf_contact_id: string
+  lead_name?: string
   contact_name?: string
   contact_email?: string
+  contact_phone?: string
+  contact_url?: string
+  contact_title?: string
+  /**
+   * Your id that identifies the Contact. Contact Custom Field Id must be defined in the global integration settings.
+   */
+  contact_external_id?: string
   /**
    * Custom fields to set on the Contact. Key should be custom field id (`cf_xxxx`).
    */

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/generated-types.ts
@@ -8,11 +8,11 @@ export interface Payload {
   contact_url?: string
   contact_title?: string
   /**
-   * Your id that identifies the Contact. Contact Custom Field Id must be defined in the global integration settings.
+   * Your ID that identifies the Contact. Contact Custom Field ID for User ID must be defined in the global integration settings.
    */
   contact_external_id?: string
   /**
-   * Custom fields to set on the Contact. Key should be custom field id (`cf_xxxx`).
+   * Custom Fields to set on the Contact. Key should be Custom Field ID (`cf_xxxx`).
    */
   contact_custom_fields?: {
     [k: string]: unknown

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
@@ -62,7 +62,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     contact_external_id: {
-      label: 'Contact Identifier',
+      label: 'Contact User ID',
       description:
         'Your ID that identifies the Contact. Contact Custom Field ID for User ID must be defined in the global integration settings.',
       type: 'string',

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
@@ -7,13 +7,13 @@ const action: ActionDefinition<Settings, Payload> = {
   description: '',
   defaultSubscription: 'type = "identify"',
   fields: {
-    external_cf_contact_id: {
-      label: 'Contact Id Custom Field',
-      description: 'Value to identify the contact. Custom Field id is defined in the main integration settings.',
+    lead_name: {
+      label: 'Lead Name',
+      description: '',
       type: 'string',
-      required: true,
+      required: false,
       default: {
-        '@path': '$.userId'
+        '@path': '$.traits.company.name'
       }
     },
     contact_name: {
@@ -22,7 +22,7 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       default: {
-        '@path': '$.name'
+        '@path': '$.traits.name'
       }
     },
     contact_email: {
@@ -31,7 +31,44 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'string',
       required: false,
       default: {
-        '@path': '$.email'
+        '@path': '$.traits.email'
+      }
+    },
+    contact_phone: {
+      label: 'Contact Phone',
+      description: '',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.traits.phone'
+      }
+    },
+    contact_url: {
+      label: 'Contact Url',
+      description: '',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.traits.website'
+      }
+    },
+    contact_title: {
+      label: 'Contact Title',
+      description: '',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.traits.title'
+      }
+    },
+    contact_external_id: {
+      label: 'Contact External Id',
+      description:
+        'Your id that identifies the Contact. Contact Custom Field Id must be defined in the global integration settings.',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.userId'
       }
     },
     contact_custom_fields: {
@@ -40,11 +77,12 @@ const action: ActionDefinition<Settings, Payload> = {
       type: 'object'
     }
   },
+
   perform: (request, data) => {
     const settings = {
       contact_custom_field_id_for_user_id: data.settings.contact_custom_field_id_for_user_id
     }
-    return request('https://services.close.com/webhooks/segment/create-update-contact-and-lead', {
+    return request('https://services.close.com/webhooks/segment/actions/create-update-contact-and-lead', {
       method: 'post',
       json: { action_payload: data.payload, settings }
     })

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
@@ -3,7 +3,7 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Create Update Contact and Lead',
+  title: 'Create or Update Contact and Lead',
   description: '',
   defaultSubscription: 'type = "identify"',
   fields: {
@@ -44,7 +44,7 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     contact_url: {
-      label: 'Contact Url',
+      label: 'Contact URL',
       description: '',
       type: 'string',
       required: false,
@@ -62,9 +62,9 @@ const action: ActionDefinition<Settings, Payload> = {
       }
     },
     contact_external_id: {
-      label: 'Contact External Id',
+      label: 'Contact Identifier',
       description:
-        'Your id that identifies the Contact. Contact Custom Field Id must be defined in the global integration settings.',
+        'Your ID that identifies the Contact. Contact Custom Field ID for User ID must be defined in the global integration settings.',
       type: 'string',
       required: false,
       default: {
@@ -73,7 +73,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     contact_custom_fields: {
       label: 'Contact Custom Fields',
-      description: 'Custom fields to set on the Contact. Key should be custom field id (`cf_xxxx`).',
+      description: 'Custom Fields to set on the Contact. Key should be Custom Field ID (`cf_xxxx`).',
       type: 'object'
     }
   },
@@ -82,7 +82,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const settings = {
       contact_custom_field_id_for_user_id: data.settings.contact_custom_field_id_for_user_id
     }
-    return request('https://services.close.com/webhooks/segment/actions/create-update-contact-and-lead', {
+    return request('https://services.close.com/webhooks/segment/actions/create-update-contact-and-lead/', {
       method: 'post',
       json: { action_payload: data.payload, settings }
     })

--- a/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
+++ b/packages/destination-actions/src/destinations/close/createUpdateContactAndLead/index.ts
@@ -1,0 +1,54 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Create Update Contact and Lead',
+  description: '',
+  defaultSubscription: 'type = "identify"',
+  fields: {
+    external_cf_contact_id: {
+      label: 'Contact Id Custom Field',
+      description: 'Value to identify the contact. Custom Field id is defined in the main integration settings.',
+      type: 'string',
+      required: true,
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    contact_name: {
+      label: 'Contact Name',
+      description: '',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.name'
+      }
+    },
+    contact_email: {
+      label: 'Contact Email',
+      description: '',
+      type: 'string',
+      required: false,
+      default: {
+        '@path': '$.email'
+      }
+    },
+    contact_custom_fields: {
+      label: 'Contact Custom Fields',
+      description: 'Custom fields to set on the Contact. Key should be custom field id (`cf_xxxx`).',
+      type: 'object'
+    }
+  },
+  perform: (request, data) => {
+    const settings = {
+      contact_custom_field_id_for_user_id: data.settings.contact_custom_field_id_for_user_id
+    }
+    return request('https://services.close.com/webhooks/segment/create-update-contact-and-lead', {
+      method: 'post',
+      json: { action_payload: data.payload, settings }
+    })
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/close/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/generated-types.ts
@@ -6,7 +6,7 @@ export interface Settings {
    */
   api_key: string
   /**
-   * Enter the ID of a Contact Custom Field that'll be used to store User ID. You'll need to create this Contact Custom Field in Close first, and then the integration will use this field to store the User ID when creating new contacts, and/or will be used as a lookup key when updating existing Contacts. If this field is not filled out, Identify will only lookup and de-dupe based on email.
+   * Enter the ID of a Contact Custom Field that'll be used to store User ID. You'll need to create this Contact Custom Field in Close first, and then the integration will use this field to store the User ID when creating new contacts, and/or will be used as a lookup key when updating existing Contacts. If this field is not filled out, it will only lookup and de-dupe based on email.
    */
   contact_custom_field_id_for_user_id?: string
 }

--- a/packages/destination-actions/src/destinations/close/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * Your Close api key.
+   * Your Close API key.
    */
   api_key: string
   /**

--- a/packages/destination-actions/src/destinations/close/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * Your Close api key
+   * Your Close api key.
    */
   api_key: string
   /**

--- a/packages/destination-actions/src/destinations/close/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/generated-types.ts
@@ -1,0 +1,8 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Settings {
+  /**
+   * Your Close api key
+   */
+  apiKey: string
+}

--- a/packages/destination-actions/src/destinations/close/generated-types.ts
+++ b/packages/destination-actions/src/destinations/close/generated-types.ts
@@ -4,5 +4,9 @@ export interface Settings {
   /**
    * Your Close api key
    */
-  apiKey: string
+  api_key: string
+  /**
+   * Enter the ID of a Contact Custom Field that'll be used to store User ID. You'll need to create this Contact Custom Field in Close first, and then the integration will use this field to store the User ID when creating new contacts, and/or will be used as a lookup key when updating existing Contacts. If this field is not filled out, Identify will only lookup and de-dupe based on email.
+   */
+  contact_custom_field_id_for_user_id?: string
 }

--- a/packages/destination-actions/src/destinations/close/index.ts
+++ b/packages/destination-actions/src/destinations/close/index.ts
@@ -12,8 +12,8 @@ const destination: DestinationDefinition<Settings> = {
     scheme: 'basic',
     fields: {
       api_key: {
-        label: 'Api key',
-        description: 'Your Close api key.',
+        label: 'API key',
+        description: 'Your Close API key.',
         type: 'string',
         required: true
       },

--- a/packages/destination-actions/src/destinations/close/index.ts
+++ b/packages/destination-actions/src/destinations/close/index.ts
@@ -1,0 +1,40 @@
+import type { DestinationDefinition } from '@segment/actions-core'
+import type { Settings } from './generated-types'
+
+const destination: DestinationDefinition<Settings> = {
+  name: 'Close',
+  slug: 'close',
+  mode: 'cloud',
+
+  authentication: {
+    scheme: 'basic',
+    fields: {
+      apiKey: {
+        label: 'Api key',
+        description: 'Your Close api key.',
+        type: 'string',
+        required: true
+      }
+    },
+    testAuthentication: (request) => {
+      return request(`https://api.close.com/api/v1/me/`)
+    }
+  },
+
+  extendRequest({ settings }) {
+    return {
+      username: settings.apiKey,
+      password: '' // Blank password https://developer.close.com/topics/authentication/
+    }
+  },
+
+  // onDelete: async (request, { settings, payload }) => {
+  //   // Return a request that performs a GDPR delete for the provided Segment userId or anonymousId
+  //   // provided in the payload. If your destination does not support GDPR deletion you should not
+  //   // implement this function and should remove it completely.
+  // },
+
+  actions: {}
+}
+
+export default destination

--- a/packages/destination-actions/src/destinations/close/index.ts
+++ b/packages/destination-actions/src/destinations/close/index.ts
@@ -1,6 +1,8 @@
 import type { DestinationDefinition } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
+import createUpdateContactAndLead from './createUpdateContactAndLead'
+
 const destination: DestinationDefinition<Settings> = {
   name: 'Close',
   slug: 'close',
@@ -9,11 +11,25 @@ const destination: DestinationDefinition<Settings> = {
   authentication: {
     scheme: 'basic',
     fields: {
-      apiKey: {
+      api_key: {
         label: 'Api key',
         description: 'Your Close api key.',
         type: 'string',
         required: true
+      },
+      contact_custom_field_id_for_user_id: {
+        label: 'Contact Custom Field ID for User ID',
+        description:
+          "Enter the ID of a Contact Custom Field that'll be " +
+          "used to store User ID. You'll need to create this Contact " +
+          'Custom Field in Close first, and then the integration will use ' +
+          'this field to store the User ID when creating new contacts, ' +
+          'and/or will be used as a lookup key when updating existing ' +
+          'Contacts. If this field is not filled out, Identify will only ' +
+          'lookup and de-dupe based on email.',
+        type: 'string',
+        default: '',
+        required: false
       }
     },
     testAuthentication: (request) => {
@@ -23,7 +39,7 @@ const destination: DestinationDefinition<Settings> = {
 
   extendRequest({ settings }) {
     return {
-      username: settings.apiKey,
+      username: settings.api_key,
       password: '' // Blank password https://developer.close.com/topics/authentication/
     }
   },
@@ -34,7 +50,9 @@ const destination: DestinationDefinition<Settings> = {
   //   // implement this function and should remove it completely.
   // },
 
-  actions: {}
+  actions: {
+    createUpdateContactAndLead
+  }
 }
 
 export default destination

--- a/packages/destination-actions/src/destinations/close/index.ts
+++ b/packages/destination-actions/src/destinations/close/index.ts
@@ -25,7 +25,7 @@ const destination: DestinationDefinition<Settings> = {
           'Custom Field in Close first, and then the integration will use ' +
           'this field to store the User ID when creating new contacts, ' +
           'and/or will be used as a lookup key when updating existing ' +
-          'Contacts. If this field is not filled out, Identify will only ' +
+          'Contacts. If this field is not filled out, it will only ' +
           'lookup and de-dupe based on email.',
         type: 'string',
         default: '',


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Adds Destination Action for [Close CRM](http://close.com/) that creates or updates a lead and a contact.

- We want to make this Action available only for our Workspace for testing purposes. We are planning to iterate on it in the next weeks to make it ready for our customers.
- We have decided to have one action for updating Lead and Contact, instead of having one action for Lead and another for Contact. It makes more sense considering how Close works with those entities.
- Due to internal implementation reasons we have decided to create a specific endpoint for this Segment action instead of using our public api.


## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

## Internal notes (to be removed)
- Deploy https://github.com/closeio/closeio/pull/27865 first
